### PR TITLE
fix: replace str_contains method wth strpos method to be compatible with php older han 8.0

### DIFF
--- a/step.php
+++ b/step.php
@@ -152,7 +152,8 @@ class qtype_wirisstep {
     public function is_answer_cached(string $answer): bool {
         $cachedresponses = $this->get_var('_response_hash') ?? '';
         $responsehash = md5($answer);
-        return str_contains($cachedresponses, $responsehash);
+
+        return strpos($cachedresponses, $responsehash) !== false || strpos($cachedresponses, $responsehash) == 0;
     }
 
     private function trim_name(string $name) {

--- a/step.php
+++ b/step.php
@@ -153,7 +153,7 @@ class qtype_wirisstep {
         $cachedresponses = $this->get_var('_response_hash') ?? '';
         $responsehash = md5($answer);
 
-        return strpos($cachedresponses, $responsehash) !== false || strpos($cachedresponses, $responsehash) == 0;
+        return strpos($cachedresponses, $responsehash) !== false;
     }
 
     private function trim_name(string $name) {


### PR DESCRIPTION
strpos() torna un enter o false, la comprovació del == 0 és per evitar 0 falsyes

Docu: https://www.php.net/manual/en/function.strpos.php